### PR TITLE
Fix URL regression, bump v1.1.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "gp-angular",
   "description": "An AngularJS SDK for the Globalization Pipeline on IBM's Bluemix",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "moduleType": "amd",
   "author": "Scott Russell <icuintl@us.ibm.com>",
   "license": "Apache 2.0",

--- a/src/gp-angular.js
+++ b/src/gp-angular.js
@@ -34,6 +34,17 @@ module.provider('GlobalizationPipelineService', [ function() {
 
     this.setGpConfig = function(newOptions) {
         gp_config = angular.copy(newOptions);
+        // verify URL
+        gp_config.credentials.url = gp_config.credentials.url || gp_config.credentials.uri;
+        if (!gp_config.credentials.url) {
+            console.log('GlobalizationPipelineService: missing credentials.url');
+            throw new Error('GlobalizationPipelineService: missing credentials.url');
+        }
+
+        // if the URL ends with “/translate”,  add “/rest”
+        if( /\/translate$/.test(gp_config.credentials.url)) {
+            gp_config.credentials.url = gp_config.credentials.url + '/rest';
+        }
     };
 
     this.$get = [ "$rootScope", "$log", "$q", "$http", "$window", function($rootScope, $log, $q, $http, $window) {
@@ -116,7 +127,7 @@ module.provider('GlobalizationPipelineService', [ function() {
          */
         function getBundleInfo(bundleId) {
             var restDefer = $q.defer();
-            var url = (gp_config.credentials.url || gp_config.credentials.uri)
+            var url = gp_config.credentials.url
                   + '/' + gp_config.credentials.instanceId + '/' + gpVersion + '/bundles' + '/' + bundleId;
             if(DEBUG) {
                 console.log('[getBundleInfo] GET ' + url);
@@ -375,7 +386,7 @@ module.provider('GlobalizationPipelineService', [ function() {
 
             getCache().addBundle(gpBundleKey, languageId, restDefer.promise);
 
-            var url = (gp_config.credentials.url || gp_config.credentials.uri)
+            var url = gp_config.credentials.url
              +  '/' + gpBundleKey + '/' + languageId;
             if(DEBUG) {
                 console.log('[newCacheRequest] GET ' + url);


### PR DESCRIPTION
Fixes: https://github.com/IBM-Bluemix/gp-angular-client/issues/13
* Append /rest if the url ends in /translate
* fixup the uri/url once
* log/exception if no credentials